### PR TITLE
fix a flaky test

### DIFF
--- a/common/src/test/java/org/apache/rocketmq/common/filter/FilterAPITest.java
+++ b/common/src/test/java/org/apache/rocketmq/common/filter/FilterAPITest.java
@@ -57,7 +57,7 @@ public class FilterAPITest {
             assertThat(ExpressionType.isTagType(subscriptionData.getExpressionType())).isTrue();
 
             assertThat(subscriptionData.getTagsSet()).isNotNull();
-            assertThat(subscriptionData.getTagsSet()).containsExactly("A", "B");
+            assertThat(subscriptionData.getTagsSet()).containsExactlyInAnyOrder("A", "B");
         } catch (Exception e) {
             e.printStackTrace();
             assertThat(Boolean.FALSE).isTrue();


### PR DESCRIPTION
**Description**
The test `org.apache.rocketmq.common.filter.FilterAPITest.testBuildTagSome` may fail 
since `getTagsSet()` returns a `HashSet` that has undetermined iteration order. One can check for that using the [NonDex](https://github.com/TestingResearchIllinois/NonDex).

**Reproduce the failure**
```
mvn install -pl common -am -DskipTests
mvn edu.illinois:nondex-maven-plugin:1.1.2:nondex -pl common -Dtest=org.apache.rocketmq.common.filter.FilterAPITest#testBuildTagSome
```

**Solution**
Use `containsExactlyInAnyOrder()` instead of `containsExactly()` for the failing AssertJ assertion.